### PR TITLE
fix: type error due to customTesters in context but not in state

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -197,7 +197,7 @@ describe('jsonContaining()', () => {
     it('should pass', () => {
         const testObj = { test: false }
         expect(
-            jsonContaining.call(null, JSON.stringify(testObj), testObj)
+            jsonContaining.call(mockedState, JSON.stringify(testObj), testObj)
         ).toMatchObject({
             pass: true
         })
@@ -207,7 +207,7 @@ describe('jsonContaining()', () => {
         const testObj = { test: false }
         const anotherTestObj = { anotherTest: false }
         expect(
-            jsonContaining.call(null, JSON.stringify(testObj), anotherTestObj)
+            jsonContaining.call(mockedState, JSON.stringify(testObj), anotherTestObj)
         ).toMatchObject({
             pass: false
         })

--- a/index.ts
+++ b/index.ts
@@ -71,6 +71,6 @@ export function toMatchJSON(this: MatcherState, received: unknown, jsonObject: a
     return matchers.toMatchObject.call(this, JSON.parse(received as string), jsonObject)
 }
 
-export function jsonContaining(received: unknown, jsonObject: any): ExpectationResult {
-    return toMatchJSON.call(expect.getState() as MatcherState, received, jsonObject)
+export function jsonContaining(this: MatcherState, received: unknown, jsonObject: any): ExpectationResult {
+    return toMatchJSON.call(this, received, jsonObject)
 }


### PR DESCRIPTION
Fixes #9

I think this should minimally be compatible from `expect` 27.5.1 which I see is used in `package-lock.json`.

The calling code to the matcher is

```
        asymmetricMatch(other) {
          const {pass} = matcher.call(
            this.getMatcherContext(),
            other,
            ...this.sample
          );
          return this.inverse ? !pass : pass;
        }
```
that is in `jestMatchersObject` in `expect`.

